### PR TITLE
Fix to allow dependabot PR with no review requested on slack

### DIFF
--- a/action.js
+++ b/action.js
@@ -178,6 +178,8 @@ async function actionPullRequest() {
     return;
   }
 
+  console.log(`Checking PR ${pullNumber} created by ${author}`);
+
   if (["main", "master", "preprod", "prod"].indexOf(baseRef) === -1) {
     console.log(
       `Not checking PR ${pullNumber} based on “${baseRef}”, which is an unprotected branch`

--- a/action.js
+++ b/action.js
@@ -171,14 +171,12 @@ async function actionPullRequest() {
   );
   const hasRequestedReview = getHasRequestedReview(comments);
 
-  if (author === "ms-bot") {
+  if (author === "ms-bot" || author === "dependabot[bot]") {
     console.log(
-      `Not checking PR ${pullNumber} that has been created by ms-bot`
+      `Not checking PR ${pullNumber} that has been created by ${author}`
     );
     return;
   }
-
-  console.log(`Checking PR ${pullNumber} created by ${author}`);
 
   if (["main", "master", "preprod", "prod"].indexOf(baseRef) === -1) {
     console.log(


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp;Allow dependabot PR with no review requested on slack. The case was already managed for ms-bot.

### Good To Know

👉🏻 &nbsp;https://app.asana.com/0/1200175269622723/1202360971152800/f

### QA

👉🏻 &nbsp;`npm run test`
